### PR TITLE
fix doc error

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const postCssPlugin = require("esbuild-plugin-postcss2");
 esbuild.build({
   ...
   plugins: [
-    postCssPlugin.default()
+    postCssPlugin.default({})
   ]
   ...
 });


### PR DESCRIPTION
If we use as the following code in the doc:

```js
const esbuild = require("esbuild");
const postCssPlugin = require("esbuild-plugin-postcss2");

esbuild.build({
  ...
  plugins: [
    postCssPlugin.default()
  ]
  ...
});
```

It will report the following error:

```
$ node builder.js
/repo_path/node_modules/esbuild-plugin-postcss2/dist/index.js:37
  plugins = [],
  ^

TypeError: Cannot read properties of undefined (reading 'plugins')
    at Object.postCSSPlugin (/mnt/bao/codes/personal/try-esbuild/esbuild-demo/node_modules/esbuild-plugin-postcss2/dist/index.js:37:3)
    at Object.<anonymous> (/mnt/bao/codes/personal/try-esbuild/esbuild-demo/builder.js:41:34)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
error Command failed with exit code 1.
```
