### PR TITLE
Support cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,20 +101,6 @@ const postCSSPlugin = ({
         if (!sourceFullPath)
           sourceFullPath = path.resolve(args.resolveDir, args.path);
 
-        // hack
-        let exist = existsSync(sourceFullPath + ".js");
-        if (exist) {
-          return;
-        }
-        exist = existsSync(sourceFullPath);
-        if (!exist) {
-          sourceFullPath = path.resolve(
-            process.cwd(),
-            "node_modules",
-            args.path
-          );
-        }
-
         const sourceExt = path.extname(sourceFullPath);
         const sourceBaseName = path.basename(sourceFullPath, sourceExt);
         const isModule = sourceBaseName.match(/\.module$/);


### PR DESCRIPTION
## Background

I use this plugin to compile the less and less module CSS files with esbuild for my a little large project. It works fine in the production mode, but in the dev mode, when we modify a CSS file, it cost more than 4s to make a rebuild, even we enable the `incremental: true` option. It doesn't satisfy us.

After investigating, we found the pure js code only cost hundreds of milliseconds to rebuild, most of the rebuild time is cost by compiling CSS.

According to the [official advice](https://esbuild.github.io/plugins/#caching-your-plugin), we can add the cache strategy for the plugin. So I try it, and it works amazing, the rebuild time is reduced from more than **4s** to **600~700ms**.

## Result

In dev mode, enable incremental rebuild.

When `enableCache: false`, after changing a line of CSS code:

```
```

When `enableCache: true`, after changing a line of CSS code:

```
```

